### PR TITLE
Bump Docker Python version to 3.10; pin pyzmq version to 25.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Stackoverflow question: https://stackoverflow.com/questions/53802691/pyzmq-docke
 
     docker image ls  # show docker images
     docker container ls  # show docker containers
-    docker exec -it pyzmq-docker_pub_1  # enter bash in container
+    docker exec -it pyzmq-docker_pub_1 bash  # enter bash in container
     docker attach pyzmq-docker_sub_1  # get
 
     To detach the tty without exiting the shell, use the escape sequence Ctrl+p + Ctrl+q

--- a/pub/Dockerfile
+++ b/pub/Dockerfile
@@ -1,5 +1,5 @@
 #pub
-FROM python:3.7.1-slim
+FROM python:3.10-slim
 
 MAINTAINER Stef van der Struijk <stefstruijk+github@protonmail.ch>
 

--- a/pub/requirements.txt
+++ b/pub/requirements.txt
@@ -1,1 +1,1 @@
-pyzmq
+pyzmq==25.1

--- a/sub/Dockerfile
+++ b/sub/Dockerfile
@@ -1,5 +1,5 @@
 #sub
-FROM python:3.7.1-slim
+FROM python:3.10-slim
 
 MAINTAINER Stef van der Struijk <stefstruijk+github@protonmail.ch>
 


### PR DESCRIPTION
Bump Docker Python version to 3.10; pin pyzmq version to 25.1

Also add `bash` to `docker exec -it pyzmq-docker_pub_1 bash` as this now seems required.

Solves issue: #2 
